### PR TITLE
Extend Parallel AI Queues

### DIFF
--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -19,8 +19,19 @@ public:
 		std::map<BuildingTypeExt::ExtData*, int> BuildingCounter;
 		CounterClass OwnedLimboBuildingTypes;
 
+		BuildingClass* Factory_BuildingType;
+		BuildingClass* Factory_InfantryType;
+		BuildingClass* Factory_VehicleType;
+		BuildingClass* Factory_NavyType;
+		BuildingClass* Factory_AircraftType;
+
 		ExtData(HouseClass* OwnerObject) : Extension<HouseClass>(OwnerObject)
 			, OwnedLimboBuildingTypes {}
+			, Factory_BuildingType(nullptr)
+			, Factory_InfantryType(nullptr)
+			, Factory_VehicleType(nullptr)
+			, Factory_NavyType(nullptr)
+			, Factory_AircraftType(nullptr)
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -6,6 +6,7 @@
 #include <Unsorted.h>
 #include <Drawing.h>
 
+#include "Utilities\Parser.h"
 #include <Utilities/GeneralUtils.h>
 #include <Utilities/Debug.h>
 #include <Utilities/Patch.h>
@@ -50,6 +51,7 @@ bool Phobos::Config::PrioritySelectionFiltering = true;
 bool Phobos::Config::DevelopmentCommands = true;
 bool Phobos::Config::ArtImageSwap = false;
 bool Phobos::Config::AllowParallelAIQueues = true;
+bool Phobos::Config::ExtendParallelAIQueues[5] = { true, true, true, true, true };
 
 void Phobos::CmdLineParse(char** ppArgs, int nNumArgs)
 {
@@ -232,6 +234,15 @@ DEFINE_HOOK(0x66E9DF, RulesClass_Process_Phobos, 0x8)
 	// Ares tags
 	Phobos::Config::DevelopmentCommands = rulesINI->ReadBool("GlobalControls", "DebugKeysEnabled", Phobos::Config::DevelopmentCommands);
 	Phobos::Config::AllowParallelAIQueues = rulesINI->ReadBool("GlobalControls", "AllowParallelAIQueues", Phobos::Config::AllowParallelAIQueues);
+
+	if (rulesINI->ReadString("GlobalControls", "ExtendParallelAIQueues", "", Phobos::readBuffer))
+	{
+		bool temp[5] = {};
+		int read = Parser<bool, 5>::Parse(Phobos::readBuffer, temp);
+
+		for (int i = 0; i < read; ++i)
+			Phobos::Config::ExtendParallelAIQueues[i] = temp[i];
+	}
 
 	return 0;
 }

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -66,5 +66,6 @@ public:
 		static bool DevelopmentCommands;
 		static bool ArtImageSwap;
 		static bool AllowParallelAIQueues;
+		static bool ExtendParallelAIQueues[5];
 	};
 };


### PR DESCRIPTION
In the vanilla game, you could make the AI construct multiple factories by using cloned BuildingTypes whit TechLevel=-1 and AIBuildThis=yes.
Ares can alter the vanilla game behaviour so that this cloning issue no longer occurs when the AI owns more than one of any factory. But we still can't set it for some type of factory.

Now we can set it on specified types of factories do not occurs cloning issue and others will not be affected.

To prevent conflict with Ares, this only work when AllowParallelAIQueues=yes.

code example:
in rulesmd.ini
[GlobalControls]
ExtendParallelAIQueues=yes,yes,yes,yes,yes (list of boolean, corresponding to InfantryTypes, Vehicle without Naval, Vehicle with Naval, Aircraft, Building)