### PR TITLE
一些修复

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -416,4 +416,3 @@ This page lists all the individual contributions to the project by their author.
 - **Damfoos** - extensive and thorough testing
 - **Dmitry Volkov** - extensive and thorough testing
 - **Rise of the East community** - extensive playtesting of in-dev features
-- **Aephiex** - fixed Ares academy not working on the initial payloads of vehicles built from a war factory

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -335,6 +335,7 @@ This page lists all the individual contributions to the project by their author.
    - Ares' Abductor weapon fix
    - Suppress Ares' swizzle warning when parsing tags and taskforces
    - Better fix for Ares academy not working on the initial payloads of vehicles built from a war factory
+   - Fix Ares' InitialPayload for teams spawned by trigger actions
    - Misc code refactor & maintenance, CN doc fixes, bugfixes
 - **FlyStar**
    - Campaign load screen PCX support
@@ -374,6 +375,8 @@ This page lists all the individual contributions to the project by their author.
 - **CrimRecya**
   - Fix `LimboKill` not working reliably
   - Exclusive SuperWeapon Sidebar
+  - Allow using waypoints, area guard and attack move with aircraft
+  - Fix `Stop` command not working so well in some cases
 - **Ollerus**
   - Build limit group enhancement
   - Customizable rocker amplitude
@@ -409,6 +412,7 @@ This page lists all the individual contributions to the project by their author.
 - **thomassneddon** - general assistance, knowledge about voxel lighting model
 - **Xkein** - general assistance, YRpp edits
 - **mevitar** - honorary shield tester *triple* award
+- **Phobos CN Tester Group (Reedom, Mantis, Swim Wing, Takitoru, Examon, AKB, Pusheen, ZQ, Claptrap, BunkerGeneral, Big J, Skywalker, ChickEmperor, Shifty, Mikain, Tobiichi Origami, Feiron, W_S502, Ailink, AbrahamMikhail, Tide, Fnfalsc, Yumeri_Rei, Nacho, Zhuzi, Ika_Aru)** - extensive and thorough testing
 - **Damfoos** - extensive and thorough testing
 - **Dmitry Volkov** - extensive and thorough testing
 - **Rise of the East community** - extensive playtesting of in-dev features

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -27,12 +27,6 @@ In rulesmd.ini:
 RepairBaseNodes=false              ; boolean
 ```
 
-In rulesmd.ini:
-```ini
-[General]
-RepairBaseNodes=false,false,false  ; list of 3 booleans indicating whether AI repair basenodes in Easy / Normal / Difficult game diffculty.
-```
-
 In map file:
 ```ini
 [Country House]

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -186,6 +186,21 @@ git config --global branch.autoSetupRebase always
 git config --global diff.colorMoved zebra
 ```
 
+### Working with YRpp via submodules
+
+Often when working on Phobos and/or researching the YR engine you'll need to implement corrections for YRpp. Generally the corrections need to be submitted to [YRpp repository](https://github.com/Phobos-developers/YRpp) and can be done separately from the actual features in Phobos, but frequently the improvements are to be submitted as a part of Phobos contribution process. To submit improvements to YRpp you have to create a branch in YRpp, then you can push it and submit a pull request to YRpp repository.
+
+When you clone Phobos recursively - you also clone YRpp as a submodule. Basically submodules are just nested repositories. You can open it like any other repository, so the changes can be synchronized to Phobos and you don't need to rename stuff by hand.
+
+The suggested workflow is as follows:
+1. In your IDE of choice rename fields and functions using symbol renaming feature (`Rename...` feature in Visual Studio (regular or Code), `[F2]` by default), then you will have two "levels" of changes displayed in your Git client:
+   - for Phobos repository - changes in the Phobos code (as regular changes) and changes to YRpp (as one submodule change)
+   - for YRpp repository - changes to the field names and function names in YRpp as regular changes.
+2. Create a branch in YRpp repository (create a fork of it if you didn't yet), commit and push the changes and submit it as a pull request. After pushing it you have two options in Phobos repository:
+   - wait until it's accepted, then checkout YRpp at the newest commit, then commit and push - this will save you having to commit and push multiple times, but you won't be able to get a nightly build for people to test;
+   - don't wait for YRpp changes to be merged, commit and push right after you pushed the YRpp changes to your YRpp branch - you will have an up-to-date build on Phobos pull request this way. Note that you must do this only after you committed to and pushed your YRpp branch, otherwise the build system won't know what are the changes as they are not exposed to the world, only available to you locally.
+3. After the YRpp pull request gets accepted you will need to switch to the latest commit that was merged (you do that in the submodule), verify that it compiles like normal, and then commit and push it to your Phobos branch that you made for your pull request.
+
 ## Ways to help
 
 Engine modding is a complicated process which is pretty hard to pull off, but there are also easier parts which don't require mastering the art of reverse-engineering or becoming a dank magician in C++.

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -176,6 +176,13 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - `<Player @ X>` can now be used as owner for pre-placed objects on skirmish and multiplayer maps.
 - Follower vehicle index for preplaced vehicles in maps is now explicitly constrained to `[Units]` list in map files and is no longer thrown off by vehicles that could not be created or created vehicles having other vehicles as initial passengers.
 - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix
+- Stop command (`[S]` by default) behavior is now more correct:
+  - Jumpjets no longer fall into a state of standing by idly.
+  - Technos are no longer unable to stop the attack move mission.
+  - Technos are no longer unable to stop the area guard mission.
+  - Aircraft no longer find airport twice and overlap.
+  - Aircraft no longer briefly pause in the air before returning.
+  - Aircraft with `AirportBound=no` continue moving forward.
 - Unit `Speed` setting now accepts floating-point values. Internally parsed values are clamped down to maximum of 100, multiplied by 256 and divided by 100, the result (which at this point is converted to an integer) then clamped down to maximum of 255 giving effective internal speed value range of 0 to 255, e.g leptons traveled per game frame.
 - Subterranean movement now benefits from speed multipliers from all sources such as veterancy, AttachEffect etc.
 
@@ -192,7 +199,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed Ares' Abductor weapon leaves permanent placement stats when abducting moving vehicles.
 - Suppressed Ares' swizzle warning when parsing `Tags` and `TaskForces` (typically begin with `[Developer fatal]Pointer 00000000 declared change to both`).
 - Fixed Academy *(Ares feature)* not working on the initial payloads *(Ares feature)* of vehicles built from a war factory.
-
+- Fixed Ares' InitialPayload not being created for vehicles spawned by trigger actions.
 ## Aircraft
 
 ### Carryall pickup voice
@@ -226,6 +233,20 @@ In `rulesmd.ini`:
 ```ini
 [SOMEAIRCRAFT]  ; AircraftType
 LandingDir=     ; Direction type (integers from 0-255). Accepts negative values as a special case.
+```
+
+### Extended Aircraft Missions
+
+- Aircraft will now be able to use waypoints.
+- When a `guard` command (`[G]` by default) is issued, the aircraft will search for targets around the current location and return immediately when target is not found, target is destroyed or ammos are depleted.
+  - If the target is destroyed but ammos are not depleted yet, it will also return because the aircraft's command is one-time.
+- When an `attack move` command (`[Ctrl]+[Shift]`) is issued, the aircraft will move towards the destination and search for nearby targets on the route for attack. Once ammo is depleted or the destination is reached, it will return.
+  - If the automatically selected target is destroyed but ammo is not depleted yet during the process, the aircraft will continue flying to the destination.
+
+In `rulesmd.ini`:
+```ini
+[General]
+ExtendedAircraftMissions=false  ; boolean
 ```
 
 ## Animations

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -585,18 +585,22 @@ ToolTipBlur=false  ; boolean, whether the blur effect of tooltips will be enable
 - In theory, it should be compatible with Ares
 - Cameos arranged in a pyramid shape.
 - `SuperWeaponSidebar.Interval` specific how many leptons between two columns.
-- `SuperWeaponSidebar.Max` controls the maximum number of icons on the leftmost side, which also depends on the current game resolution.
+- `SuperWeaponSidebar.Max` controls the maximum number of cameos on the leftmost side, which also depends on the current game resolution.
 - `SuperWeaponSidebar.MaxColumns` controls that maximum count of columns.
+- `SuperWeaponSidebar.CameoHeight` controls the distance from the top of the previous cameo to the top of the next cameo.
+- `SuperWeaponSidebar.LeftOffset` controls the distance between the leftmost cameo and the leftmost part of the screen.
 - You can also launch first 10 SW by hotkey in INTERFACE category.
 - For localization of hotkey, add `TXT_FIRE_TACTICAL_SW_XX`, `TXT_FIRE_TACTICAL_SW_XX_DESC`, `TXT_TOGGLE_SW_SIDEBAR` and `TXT_TOGGLE_SW_SIDEBAR_DESC` into your `.csf` file.
 
 In `uimd.ini`:
 ```ini
 [Sidebar]
-SuperWeaponSidebar=false            ; boolean
-SuperWeaponSidebar.Interval=0       ; integer
-SuperWeaponSidebar.Max=0            ; integer
-SuperWeaponSidebar.MaxColumns=       ; integer
+SuperWeaponSidebar=false              ; boolean
+SuperWeaponSidebar.Interval=0         ; integer
+SuperWeaponSidebar.LeftOffset=0       ; integer
+SuperWeaponSidebar.CameoHeight=48     ; integer
+SuperWeaponSidebar.Max=0              ; integer
+SuperWeaponSidebar.MaxColumns=        ; integer
 ```
 
 In `rulesmd.ini`

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -602,16 +602,18 @@ SuperWeaponSidebar.MaxColumns=       ; integer
 In `rulesmd.ini`
 ```ini
 [SOMESIDE]
-SuperWeaponSidebar.TopShape=          ; filename - including the .shp extension
-SuperWeaponSidebar.CenterShape=     ; filename - including the .shp extension
-SuperWeaponSidebar.BottomShape=    ; filename - including the .shp extension
-SuperWeaponSidebar.ToggleShape=     ; filename - including the .shp extension
+SuperWeaponSidebar.OnPCX=             ; filename - including the .pcx extension
+SuperWeaponSidebar.OffPCX=            ; filename - including the .pcx extension
+SuperWeaponSidebar.TopPCX=            ; filename - including the .pcx extension
+SuperWeaponSidebar.CenterPCX=         ; filename - including the .pcx extension
+SuperWeaponSidebar.BottomPCX=         ; filename - including the .pcx extension
 
 [SOMESW]
 SuperWeaponSidebar.Allow=true         ; boolean
 SuperWeaponSidebar.PriorityHouses=    ; list of house types
 SuperWeaponSidebar.RequiredHouses=    ; list of house types
 ```
+
 ## Miscellanous
 
 ### Skip saving game on starting a new campaign

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -445,6 +445,7 @@ New:
 - Option for Warhead to remove all shield types at once (by Starkku)
 - Allow customizing voxel light source position (by Kerbiter, Morton, based on knowledge of thomassnedon)
 - Option to fix voxel light source being offset and incorrectly tilting on slopes (by Kerbiter)
+- Allow using waypoints, area guard and attack move with aircraft (by CrimRecya)
 - AI superweapon delay timer customization (by Starkku)
 - Disabling `MultipleFactory` bonus from specific BuildingType (by Starkku)
 - Customizable ChronoSphere teleport delays for units (by Starkku)
@@ -553,6 +554,7 @@ Vanilla fixes:
 - Fixed objects with ally target and `AttackFriendlies=true` having their target reset every frame, particularly AI-owned buildings (by Starkku)
 - Follower vehicle index for preplaced vehicles in maps is now explicitly constrained to `[Units]` list in map files and is no longer thrown off by vehicles that could not be created or created vehicles having other vehicles as initial passengers (by Starkku)
 - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix (by tyuah8)
+- Fix `Stop` command not working so well in some cases (by CrimRecya)
 - Subterranean movement now benefits from speed multipliers from all sources such as veterancy, AttachEffect etc. (by Starkku)
 
 Phobos fixes:
@@ -612,6 +614,7 @@ Fixes / interactions with other extensions:
 - Fixed Ares' Abductor weapon leaves permanent placement stats when abducting moving vehicles (by Trsdy)
 - Suppressed Ares' swizzle warning when parsing `Tags` and `TaskForces` (by Trsdy)
 - Fixed Academy *(Ares feature)* not working on the initial payloads *(Ares feature)* of vehicles built from a war factory (by Trsdy, supersedes Aephiex impl.)
+- Fixed Ares' InitialPayload not being created for vehicles spawned by trigger actions (by Trsdy)
 </details>
 
 ### 0.3.0.1

--- a/src/Ext/Aircraft/Hooks.cpp
+++ b/src/Ext/Aircraft/Hooks.cpp
@@ -318,6 +318,179 @@ DEFINE_HOOK(0x415EEE, AircraftClass_Fire_KickOutPassengers, 0x6)
 	return SkipKickOutPassengers;
 }
 
+// Aircraft mission hard code are all disposable that no ammo, target died or arrived destination all will call the aircraft return airbase
+#pragma region ExtendedAircraftMissions
+
+// Waypoint: enable and smooth moving action
+bool __fastcall AircraftTypeClass_CanUseWaypoint(AircraftTypeClass* pThis)
+{
+	return RulesExt::Global()->ExtendedAircraftMissions.Get();
+}
+DEFINE_JUMP(VTABLE, 0x7E2908, GET_OFFSET(AircraftTypeClass_CanUseWaypoint))
+
+// KickOut: skip useless tether
+DEFINE_JUMP(LJMP, 0x444021, 0x44402E)
+
+// Move: smooth the planning paths and returning route
+DEFINE_HOOK_AGAIN(0x4168C7, AircraftClass_Mission_Move_SmoothMoving, 0x5)
+DEFINE_HOOK(0x416A0A, AircraftClass_Mission_Move_SmoothMoving, 0x5)
+{
+	enum { EnterIdleAndReturn = 0x416AC0, ContinueMoving1 = 0x416908, ContinueMoving2 = 0x416A47 };
+
+	GET(AircraftClass* const, pThis, ESI);
+	GET(CoordStruct* const, pCoords, EAX);
+
+	if (!RulesExt::Global()->ExtendedAircraftMissions)
+		return 0;
+
+	const auto pType = pThis->Type;
+
+	if (!pType->AirportBound || pThis->Team || pThis->Airstrike || pThis->Spawned)
+		return 0;
+
+	const int distance = Game::F2I(Point2D { pCoords->X, pCoords->Y }.DistanceFrom(Point2D { pThis->Location.X, pThis->Location.Y }));
+
+	// When the horizontal distance between the aircraft and its destination is greater than half of its deceleration distance
+	// or its turning radius, continue to move forward, otherwise return to airbase or execute the next planning path
+	if (distance > std::max((pType->SlowdownDistance >> 1), (2048 / pType->ROT)))
+		return (R->Origin() == 0x4168C7 ? ContinueMoving1 : ContinueMoving2);
+
+	pThis->EnterIdleMode(false, true);
+
+	return EnterIdleAndReturn;
+}
+
+// AreaGuard: return when no ammo or first target died
+DEFINE_HOOK_AGAIN(0x41A982, AircraftClass_Mission_AreaGuard, 0x6)
+DEFINE_HOOK(0x41A96C, AircraftClass_Mission_AreaGuard, 0x6)
+{
+	enum { SkipGameCode = 0x41A97A };
+
+	GET(AircraftClass* const, pThis, ESI);
+
+	if (RulesExt::Global()->ExtendedAircraftMissions && !pThis->Team && pThis->Ammo && pThis->IsArmed())
+	{
+		auto coords = pThis->GetCoords();
+
+		if (pThis->TargetAndEstimateDamage(coords, ThreatType::Area))
+		{
+			pThis->QueueMission(Mission::Attack, false);
+			return SkipGameCode;
+		}
+	}
+
+	return 0;
+}
+
+// AttackMove: return when no ammo or arrived destination
+bool __fastcall AircraftTypeClass_CanAttackMove(AircraftTypeClass* pThis)
+{
+	return RulesExt::Global()->ExtendedAircraftMissions.Get();
+}
+DEFINE_JUMP(VTABLE, 0x7E290C, GET_OFFSET(AircraftTypeClass_CanAttackMove))
+
+DEFINE_HOOK(0x6FA68B, TechnoClass_Update_AttackMovePaused, 0xA) // To make aircrafts not search for targets while resting at the airport, this is designed to adapt to loop waypoint
+{
+	enum { SkipGameCode = 0x6FA6F5 };
+
+	GET(TechnoClass* const, pThis, ESI);
+
+	const bool skip = RulesExt::Global()->ExtendedAircraftMissions
+		&& pThis->WhatAmI() == AbstractType::Aircraft
+		&& (!pThis->Ammo || !pThis->IsInAir());
+
+	return skip ? SkipGameCode : 0;
+}
+
+DEFINE_HOOK(0x4DF3BA, FootClass_UpdateAttackMove_AircraftHoldAttackMoveTarget1, 0x6) // When it have MegaDestination
+{
+	enum { LoseTarget = 0x4DF3D3, HoldTarget = 0x4DF4AB };
+
+	GET(FootClass* const, pThis, ESI);
+
+	// The aircraft is constantly moving, which may cause its target to constantly enter and leave its range, so it is fixed to hold the target.
+	if (RulesExt::Global()->ExtendedAircraftMissions && pThis->WhatAmI() == AbstractType::Aircraft)
+		return HoldTarget;
+
+	return pThis->InAuxiliarySearchRange(pThis->Target) ? HoldTarget : LoseTarget;
+}
+
+DEFINE_HOOK(0x4DF42A, FootClass_UpdateAttackMove_AircraftHoldAttackMoveTarget2, 0x6) // When it have MegaTarget
+{
+	enum { ContinueCheck = 0x4DF462, HoldTarget = 0x4DF4AB };
+
+	GET(FootClass* const, pThis, ESI);
+
+	// Although if the target selected by CS is an object rather than cell.
+	return (RulesExt::Global()->ExtendedAircraftMissions && pThis->WhatAmI() == AbstractType::Aircraft) ? HoldTarget : ContinueCheck;
+}
+
+DEFINE_HOOK(0x418CD1, AircraftClass_Mission_Attack_ContinueFlyToDestination, 0x6)
+{
+	enum { Continue = 0x418C43, Return = 0x418CE8 };
+
+	GET(AircraftClass* const, pThis, ESI);
+
+	if (!pThis->Target)
+	{
+		if (!RulesExt::Global()->ExtendedAircraftMissions || !pThis->MegaMissionIsAttackMove() || !pThis->MegaDestination)
+			return Continue;
+
+		pThis->SetDestination(pThis->MegaDestination, false);
+		pThis->QueueMission(Mission::Move, true);
+		pThis->HaveAttackMoveTarget = false;
+	}
+	else
+	{
+		pThis->MissionStatus = 1;
+	}
+
+	R->EAX(1);
+	return Return;
+}
+
+// Idle: clear the target if no ammo
+DEFINE_HOOK(0x414D4D, AircraftClass_Update_ClearTargetIfNoAmmo, 0x6)
+{
+	enum { ClearTarget = 0x414D3F };
+
+	GET(AircraftClass* const, pThis, ESI);
+
+	if (RulesExt::Global()->ExtendedAircraftMissions && !pThis->Ammo && !pThis->Airstrike && !pThis->Spawned)
+	{
+		if (!SessionClass::IsCampaign()) // To avoid AI's aircrafts team repeatedly attempting to attack the target when no ammo
+		{
+			if (const auto pTeam = pThis->Team)
+				pTeam->LiberateMember(pThis);
+		}
+
+		return ClearTarget;
+	}
+
+	return 0;
+}
+
+// Stop: clear the mega mission and return to airbase immediately
+// (StopEventFix's DEFINE_HOOK(0x4C75DA, EventClass_RespondToEvent_Stop, 0x6) in Hooks.BugFixes.cpp)
+
+// GreatestThreat: for all the mission that should let the aircraft auto select a target
+AbstractClass* __fastcall AircraftClass_GreatestThreat(AircraftClass* pThis, void* _, ThreatType threatType, CoordStruct* pSelectCoords, bool onlyTargetHouseEnemy)
+{
+	if (RulesExt::Global()->ExtendedAircraftMissions)
+	{
+		if (const auto pPrimaryWeapon = pThis->GetWeapon(0)->WeaponType)
+			threatType |= pPrimaryWeapon->AllowedThreats();
+
+		if (const auto pSecondaryWeapon = pThis->GetWeapon(1)->WeaponType)
+			threatType |= pSecondaryWeapon->AllowedThreats();
+	}
+
+	return pThis->FootClass::GreatestThreat(threatType, pSelectCoords, onlyTargetHouseEnemy);
+}
+DEFINE_JUMP(VTABLE, 0x7E2668, GET_OFFSET(AircraftClass_GreatestThreat))
+
+#pragma endregion
+
 static __forceinline bool CheckSpyPlaneCameraCount(AircraftClass* pThis)
 {
 	auto const pExt = TechnoExt::ExtMap.Find(pThis);

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -137,6 +137,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 		this->HeightShadowScaling = false;
 	this->HeightShadowScaling_MinScale.Read(exINI, GameStrings::AudioVisual, "HeightShadowScaling.MinScale");
 
+	this->ExtendedAircraftMissions.Read(exINI, GameStrings::General, "ExtendedAircraftMissions");
+
 	this->AllowParallelAIQueues.Read(exINI, "GlobalControls", "AllowParallelAIQueues");
 	this->ForbidParallelAIQueues_Aircraft.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Aircraft");
 	this->ForbidParallelAIQueues_Building.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Building");
@@ -330,6 +332,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->AirShadowBaseScale_log)
 		.Process(this->HeightShadowScaling)
 		.Process(this->HeightShadowScaling_MinScale)
+		.Process(this->ExtendedAircraftMissions)
 		.Process(this->AllowParallelAIQueues)
 		.Process(this->ForbidParallelAIQueues_Aircraft)
 		.Process(this->ForbidParallelAIQueues_Building)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -93,6 +93,8 @@ public:
 		Valueable<double> HeightShadowScaling_MinScale;
 		double AirShadowBaseScale_log;
 
+		Valueable<bool> ExtendedAircraftMissions;
+
 		Valueable<bool> AllowParallelAIQueues;
 		Valueable<bool> ForbidParallelAIQueues_Aircraft;
 		Valueable<bool> ForbidParallelAIQueues_Building;
@@ -222,6 +224,8 @@ public:
 			, HeightShadowScaling { false }
 			, HeightShadowScaling_MinScale { 0.0 }
 			, AirShadowBaseScale_log { 0.693376137 }
+
+			, ExtendedAircraftMissions { false }
 
 			, AllowParallelAIQueues { true }
 			, ForbidParallelAIQueues_Aircraft { false }

--- a/src/Ext/SWType/Body.cpp
+++ b/src/Ext/SWType/Body.cpp
@@ -213,7 +213,7 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->TabIndex.Read(exINI, pSection, "TabIndex");
 	GeneralUtils::IntValidCheck(&this->TabIndex, pSection, "TabIndex", 1, 0, 3);
-    
+
 	this->SuperWeaponSidebar_Allow.Read(exINI, pSection, "SuperWeaponSidebar.Allow");
 	this->SuperWeaponSidebar_PriorityHouses = pINI->ReadHouseTypesList(pSection, "SuperWeaponSidebar.PriorityHouses", this->SuperWeaponSidebar_PriorityHouses);
 	this->SuperWeaponSidebar_RequiredHouses = pINI->ReadHouseTypesList(pSection, "SuperWeaponSidebar.RequiredHouses", this->SuperWeaponSidebar_RequiredHouses);

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -77,7 +77,7 @@ public:
 		Valueable<bool> ShowDesignatorRange;
 
 		Valueable<int> TabIndex;
-        
+
 		Valueable<bool> SuperWeaponSidebar_Allow;
 		DWORD SuperWeaponSidebar_PriorityHouses;
 		DWORD SuperWeaponSidebar_RequiredHouses;

--- a/src/Ext/Side/Body.cpp
+++ b/src/Ext/Side/Body.cpp
@@ -42,11 +42,11 @@ void SideExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->ToolTip_Background_Opacity.Read(exINI, pSection, "ToolTip.Background.Opacity");
 	this->ToolTip_Background_BlurSize.Read(exINI, pSection, "ToolTip.Background.BlurSize");
 	this->BriefingTheme = pINI->ReadTheme(pSection, "BriefingTheme", this->BriefingTheme);
-
-	this->SuperWeaponSidebar_TopShape.Read(exINI, pSection, "SuperWeaponSidebar.TopShape");
-	this->SuperWeaponSidebar_CenterShape.Read(exINI, pSection, "SuperWeaponSidebar.CenterShape");
-	this->SuperWeaponSidebar_BottomShape.Read(exINI, pSection, "SuperWeaponSidebar.BottomShape");
-	this->SuperWeaponSidebar_ToggleShape.Read(exINI, pSection, "SuperWeaponSidebar.ToggleShape");
+	this->SuperWeaponSidebar_OnPCX.Read(pINI, pSection, "SuperWeaponSidebar.OnPCX");
+	this->SuperWeaponSidebar_OffPCX.Read(pINI, pSection, "SuperWeaponSidebar.OffPCX");
+	this->SuperWeaponSidebar_TopPCX.Read(pINI, pSection, "SuperWeaponSidebar.TopPCX");
+	this->SuperWeaponSidebar_CenterPCX.Read(pINI, pSection, "SuperWeaponSidebar.CenterPCX");
+	this->SuperWeaponSidebar_BottomPCX.Read(pINI, pSection, "SuperWeaponSidebar.BottomPCX");
 }
 
 // =============================
@@ -76,10 +76,11 @@ void SideExt::ExtData::Serialize(T& Stm)
 		.Process(this->IngameScore_WinTheme)
 		.Process(this->IngameScore_LoseTheme)
 		.Process(this->BriefingTheme)
-		.Process(this->SuperWeaponSidebar_TopShape)
-		.Process(this->SuperWeaponSidebar_CenterShape)
-		.Process(this->SuperWeaponSidebar_BottomShape)
-		.Process(this->SuperWeaponSidebar_ToggleShape)
+		.Process(this->SuperWeaponSidebar_OnPCX)
+		.Process(this->SuperWeaponSidebar_OffPCX)
+		.Process(this->SuperWeaponSidebar_TopPCX)
+		.Process(this->SuperWeaponSidebar_CenterPCX)
+		.Process(this->SuperWeaponSidebar_BottomPCX)
 		;
 }
 

--- a/src/Ext/Side/Body.h
+++ b/src/Ext/Side/Body.h
@@ -36,11 +36,11 @@ public:
 		Nullable<int> ToolTip_Background_Opacity;
 		Nullable<float> ToolTip_Background_BlurSize;
 		Valueable<int> BriefingTheme;
-
-		Valueable<SHPStruct*> SuperWeaponSidebar_TopShape;
-		Valueable<SHPStruct*> SuperWeaponSidebar_CenterShape;
-		Valueable<SHPStruct*> SuperWeaponSidebar_BottomShape;
-		Valueable<SHPStruct*> SuperWeaponSidebar_ToggleShape;
+		PhobosPCXFile SuperWeaponSidebar_OnPCX;
+		PhobosPCXFile SuperWeaponSidebar_OffPCX;
+		PhobosPCXFile SuperWeaponSidebar_TopPCX;
+		PhobosPCXFile SuperWeaponSidebar_CenterPCX;
+		PhobosPCXFile SuperWeaponSidebar_BottomPCX;
 
 		ExtData(SideClass* OwnerObject) : Extension<SideClass>(OwnerObject)
 			, ArrayIndex { -1 }
@@ -63,10 +63,11 @@ public:
 			, ToolTip_Background_Opacity { }
 			, ToolTip_Background_BlurSize { }
 			, BriefingTheme { -1 }
-			, SuperWeaponSidebar_TopShape { }
-			, SuperWeaponSidebar_CenterShape { }
-			, SuperWeaponSidebar_BottomShape { }
-			, SuperWeaponSidebar_ToggleShape { nullptr }
+			, SuperWeaponSidebar_OnPCX {}
+			, SuperWeaponSidebar_OffPCX {}
+			, SuperWeaponSidebar_TopPCX {}
+			, SuperWeaponSidebar_CenterPCX {}
+			, SuperWeaponSidebar_BottomPCX {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Sidebar/SWSidebar/SWButtonClass.cpp
+++ b/src/Ext/Sidebar/SWSidebar/SWButtonClass.cpp
@@ -197,7 +197,7 @@ bool SWButtonClass::LaunchSuper() const
 			{
 				DisplayClass::Instance->CurrentBuilding = nullptr;
 				DisplayClass::Instance->CurrentBuildingType = nullptr;
-				DisplayClass::Instance->unknown_11AC = static_cast<DWORD>(-1);
+				DisplayClass::Instance->CurrentBuildingOwnerArrayIndex = -1;
 				DisplayClass::Instance->SetActiveFoundation(nullptr);
 				MapClass::Instance->SetRepairMode(0);
 				DisplayClass::Instance->SetSellMode(0);

--- a/src/Ext/Sidebar/SWSidebar/SWButtonClass.cpp
+++ b/src/Ext/Sidebar/SWSidebar/SWButtonClass.cpp
@@ -148,14 +148,14 @@ void SWButtonClass::OnMouseLeave()
 
 bool SWButtonClass::Action(GadgetFlag flags, DWORD* pKey, KeyModifier modifier)
 {
-	if ((int)flags & (int)GadgetFlag::LeftPress)
+	if (flags & GadgetFlag::LeftPress)
 	{
 		MouseClass::Instance->UpdateCursor(MouseCursorType::Default, false);
 		VocClass::PlayGlobal(RulesClass::Instance->GUIBuildSound, 0x2000, 1.0);
 		this->LaunchSuper();
 	}
 
-	return this->ControlClass::Action(flags, pKey, KeyModifier::None);
+	return this->GadgetClass::Action(flags, pKey, KeyModifier::None);
 }
 
 void SWButtonClass::SetColumn(int column)
@@ -200,7 +200,7 @@ bool SWButtonClass::LaunchSuper() const
 				DisplayClass::Instance->CurrentBuildingOwnerArrayIndex = -1;
 				DisplayClass::Instance->SetActiveFoundation(nullptr);
 				MapClass::Instance->SetRepairMode(0);
-				DisplayClass::Instance->SetSellMode(0);
+				MapClass::Instance->SetSellMode(0);
 				DisplayClass::Instance->PowerToggleMode = false;
 				DisplayClass::Instance->PlanningMode = false;
 				DisplayClass::Instance->PlaceBeaconMode = false;

--- a/src/Ext/Sidebar/SWSidebar/SWColumnClass.cpp
+++ b/src/Ext/Sidebar/SWSidebar/SWColumnClass.cpp
@@ -131,7 +131,6 @@ bool SWColumnClass::RemoveButton(int superIdx)
 
 	DLLDelete(*it);
 	buttons.erase(it);
-	SWSidebarClass::Instance.SortButtons();
 	return true;
 }
 

--- a/src/Ext/Sidebar/SWSidebar/SWColumnClass.cpp
+++ b/src/Ext/Sidebar/SWSidebar/SWColumnClass.cpp
@@ -35,13 +35,13 @@ bool SWColumnClass::Draw(bool forced)
 
 	if (const auto pTopPCX = pSideExt->SuperWeaponSidebar_TopPCX.GetSurface())
 	{
-		RectangleStruct drawRect { this->X, this->Y - 20, cameoBackgroundWidth, 20 };
+		RectangleStruct drawRect { this->X, this->Y, cameoBackgroundWidth, 20 };
 		PCX::Instance->BlitToSurface(&drawRect, DSurface::Composite, pTopPCX);
 	}
 
 	if (const auto pBottomPCX = pSideExt->SuperWeaponSidebar_BottomPCX.GetSurface())
 	{
-		RectangleStruct drawRect { this->X, this->Y + this->Height, cameoBackgroundWidth, 20 };
+		RectangleStruct drawRect { this->X, this->Y + this->Height - 20, cameoBackgroundWidth, 20 };
 		PCX::Instance->BlitToSurface(&drawRect, DSurface::Composite, pBottomPCX);
 	}
 
@@ -57,11 +57,13 @@ void SWColumnClass::OnMouseEnter()
 		return;
 
 	SWSidebarClass::Instance.CurrentColumn = this;
+	MouseClass::Instance->UpdateCursor(MouseCursorType::Default, false);
 }
 
 void SWColumnClass::OnMouseLeave()
 {
 	SWSidebarClass::Instance.CurrentColumn = nullptr;
+	MouseClass::Instance->UpdateCursor(MouseCursorType::Default, false);
 }
 
 bool SWColumnClass::Clicked(DWORD* pKey, GadgetFlag flags, int x, int y, KeyModifier modifier)
@@ -149,5 +151,7 @@ void SWColumnClass::ClearButtons(bool remove)
 
 void SWColumnClass::SetHeight(int height)
 {
-	this->Height = height;
+	const auto pSideExt = SideExt::ExtMap.Find(SideClass::Array->Items[ScenarioClass::Instance->PlayerSideIndex]);
+
+	this->Height = height + (pSideExt->SuperWeaponSidebar_TopPCX.GetSurface() ? 20 : 0) + (pSideExt->SuperWeaponSidebar_BottomPCX.GetSurface() ? 20 : 0);
 }

--- a/src/Ext/Sidebar/SWSidebar/SWColumnClass.cpp
+++ b/src/Ext/Sidebar/SWSidebar/SWColumnClass.cpp
@@ -105,8 +105,8 @@ bool SWColumnClass::AddButton(int superIdx)
 	if (static_cast<int>(buttons.size()) >= this->MaxButtons && !SWSidebarClass::Instance.AddColumn())
 		return false;
 
-	const int cameoWidth = 60;
-	const auto button = DLLCreate<SWButtonClass>(SWButtonClass::StartID + superIdx, superIdx, 0, 0, cameoWidth, Phobos::UI::SuperWeaponSidebar_CameoHeight);
+	const int cameoWidth = 60, cameoHeight = 48;
+	const auto button = DLLCreate<SWButtonClass>(SWButtonClass::StartID + superIdx, superIdx, 0, 0, cameoWidth, cameoHeight);
 
 	if (!button)
 		return false;

--- a/src/Ext/Sidebar/SWSidebar/SWColumnClass.cpp
+++ b/src/Ext/Sidebar/SWSidebar/SWColumnClass.cpp
@@ -18,30 +18,31 @@ bool SWColumnClass::Draw(bool forced)
 	if (!SWSidebarClass::IsEnabled())
 		return false;
 
-	const auto pSurface = DSurface::Composite();
-	auto bounds = pSurface->GetRect();
-
 	const auto pSideExt = SideExt::ExtMap.Find(SideClass::Array->Items[ScenarioClass::Instance->PlayerSideIndex]);
+	const int cameoWidth = 60, cameoHeight = 48;
+	const int cameoBackgroundWidth = Phobos::UI::SuperWeaponSidebar_Interval + cameoWidth;
 
-	if (const auto centerShape = pSideExt->SuperWeaponSidebar_CenterShape.Get())
+	if (const auto pCenterPCX = pSideExt->SuperWeaponSidebar_CenterPCX.GetSurface())
 	{
+		const int cameoHarfInterval = (Phobos::UI::SuperWeaponSidebar_CameoHeight - cameoHeight) / 2;
+
 		for (const auto button : this->Buttons)
 		{
-			Point2D drawPoint = { this->X, button->Y };
-			pSurface->DrawSHP(FileSystem::SIDEBAR_PAL, centerShape, 0, &drawPoint, &bounds, BlitterFlags::bf_400, 0, 0, ZGradient::Ground, 1000, 0, nullptr, 0, 0, 0);
+			RectangleStruct drawRect { this->X, button->Y - cameoHarfInterval, cameoBackgroundWidth, Phobos::UI::SuperWeaponSidebar_CameoHeight };
+			PCX::Instance->BlitToSurface(&drawRect, DSurface::Composite, pCenterPCX);
 		}
 	}
 
-	if (const auto topShape = pSideExt->SuperWeaponSidebar_TopShape.Get())
+	if (const auto pTopPCX = pSideExt->SuperWeaponSidebar_TopPCX.GetSurface())
 	{
-		Point2D drawPoint = { this->X, this->Y - topShape->Height };
-		pSurface->DrawSHP(FileSystem::SIDEBAR_PAL, topShape, 0, &drawPoint, &bounds, BlitterFlags::bf_400, 0, 0, ZGradient::Ground, 1000, 0, nullptr, 0, 0, 0);
+		RectangleStruct drawRect { this->X, this->Y - 20, cameoBackgroundWidth, 20 };
+		PCX::Instance->BlitToSurface(&drawRect, DSurface::Composite, pTopPCX);
 	}
 
-	if (const auto bottomShape = pSideExt->SuperWeaponSidebar_BottomShape.Get())
+	if (const auto pBottomPCX = pSideExt->SuperWeaponSidebar_BottomPCX.GetSurface())
 	{
-		Point2D drawPoint = { this->X, this->Y + this->Height };
-		pSurface->DrawSHP(FileSystem::SIDEBAR_PAL, bottomShape, 0, &drawPoint, &bounds, BlitterFlags::bf_400, 0, 0, ZGradient::Ground, 1000, 0, nullptr, 0, 0, 0);
+		RectangleStruct drawRect { this->X, this->Y + this->Height, cameoBackgroundWidth, 20 };
+		PCX::Instance->BlitToSurface(&drawRect, DSurface::Composite, pBottomPCX);
 	}
 
 	for (const auto button : this->Buttons)

--- a/src/Ext/Sidebar/SWSidebar/SWSidebarClass.cpp
+++ b/src/Ext/Sidebar/SWSidebar/SWSidebarClass.cpp
@@ -145,7 +145,7 @@ void SWSidebarClass::SortButtons()
 		const auto column = columns[columnIdx];
 
 		if (rowIdx == 0)
-			column->SetPosition(location.X - Phobos::UI::SuperWeaponSidebar_LeftOffset, location.Y);
+			column->SetPosition(location.X - Phobos::UI::SuperWeaponSidebar_LeftOffset, location.Y - (SideExt::ExtMap.Find(SideClass::Array->Items[ScenarioClass::Instance->PlayerSideIndex])->SuperWeaponSidebar_TopPCX.GetSurface() ? 20 : 0));
 
 		column->Buttons.emplace_back(button);
 		button->SetColumn(columnIdx);

--- a/src/Ext/Sidebar/SWSidebar/SWSidebarClass.cpp
+++ b/src/Ext/Sidebar/SWSidebar/SWSidebarClass.cpp
@@ -124,8 +124,19 @@ void SWSidebarClass::SortButtons()
 		column->ClearButtons(false);
 	}
 
-	std::stable_sort(vec_Buttons.begin(), vec_Buttons.end(), [](SWButtonClass* const a, SWButtonClass* const b)
+	const unsigned int ownerBits = 1u << HouseClass::CurrentPlayer->Type->ArrayIndex;
+
+	std::stable_sort(vec_Buttons.begin(), vec_Buttons.end(), [ownerBits](SWButtonClass* const a, SWButtonClass* const b)
 		{
+			const auto pExtA = SWTypeExt::ExtMap.Find(SuperWeaponTypeClass::Array->GetItemOrDefault(a->SuperIndex));
+			const auto pExtB = SWTypeExt::ExtMap.Find(SuperWeaponTypeClass::Array->GetItemOrDefault(b->SuperIndex));
+
+			if (pExtB && (pExtB->SuperWeaponSidebar_PriorityHouses & ownerBits) && (!pExtA || !(pExtA->SuperWeaponSidebar_PriorityHouses & ownerBits)))
+				return false;
+
+			if ((!pExtB || !(pExtB->SuperWeaponSidebar_PriorityHouses & ownerBits)) && pExtA && (pExtA->SuperWeaponSidebar_PriorityHouses & ownerBits))
+				return true;
+
 			return BuildType::SortsBefore(AbstractType::Special, a->SuperIndex, AbstractType::Special, b->SuperIndex);
 		});
 

--- a/src/Ext/Sidebar/SWSidebar/SWSidebarClass.cpp
+++ b/src/Ext/Sidebar/SWSidebar/SWSidebarClass.cpp
@@ -9,7 +9,6 @@
 SWSidebarClass SWSidebarClass::Instance;
 CommandClass* SWSidebarClass::Commands[10];
 
-
 // =============================
 // functions
 

--- a/src/Ext/Sidebar/SWSidebar/SWSidebarClass.cpp
+++ b/src/Ext/Sidebar/SWSidebar/SWSidebarClass.cpp
@@ -18,7 +18,8 @@ bool SWSidebarClass::AddColumn()
 	if (static_cast<int>(columns.size()) >= Phobos::UI::SuperWeaponSidebar_MaxColumns)
 		return false;
 
-	const auto column = DLLCreate<SWColumnClass>(SWButtonClass::StartID + SuperWeaponTypeClass::Array->Count + 1 + static_cast<int>(columns.size()), 0, 0, 60 + Phobos::UI::SuperWeaponSidebar_Interval, 48);
+	const int cameoWidth = 60;
+	const auto column = DLLCreate<SWColumnClass>(SWButtonClass::StartID + SuperWeaponTypeClass::Array->Count + 1 + static_cast<int>(columns.size()), 0, 0, cameoWidth + Phobos::UI::SuperWeaponSidebar_Interval, Phobos::UI::SuperWeaponSidebar_CameoHeight);
 
 	if (!column)
 		return false;
@@ -143,8 +144,10 @@ void SWSidebarClass::SortButtons()
 	const int buttonCount = static_cast<int>(vec_Buttons.size());
 	const int cameoWidth = 60, cameoHeight = 48;
 	const int maximum = Phobos::UI::SuperWeaponSidebar_Max;
-	Point2D location = { 0, (DSurface::ViewBounds().Height - std::min(buttonCount, maximum) * cameoHeight) / 2 };
-	int location_Y = location.Y;
+	const int cameoHarfInterval = (Phobos::UI::SuperWeaponSidebar_CameoHeight - cameoHeight) / 2;
+	int location_Y = (DSurface::ViewBounds().Height - std::min(buttonCount, maximum) * Phobos::UI::SuperWeaponSidebar_CameoHeight) / 2;
+	Point2D location = { Phobos::UI::SuperWeaponSidebar_LeftOffset, location_Y };
+	location_Y -= cameoHarfInterval;
 	int rowIdx = 0, columnIdx = 0;
 
 	for (const auto button : vec_Buttons)
@@ -152,7 +155,7 @@ void SWSidebarClass::SortButtons()
 		const auto column = columns[columnIdx];
 
 		if (rowIdx == 0)
-			column->SetPosition(location.X, location.Y);
+			column->SetPosition(location.X - Phobos::UI::SuperWeaponSidebar_LeftOffset, location.Y);
 
 		column->Buttons.emplace_back(button);
 		button->SetColumn(columnIdx);
@@ -163,17 +166,18 @@ void SWSidebarClass::SortButtons()
 		{
 			rowIdx = 0;
 			columnIdx++;
-			location_Y += cameoHeight / 2;
-			location = { location.X + cameoWidth + Phobos::UI::SuperWeaponSidebar_Interval, location_Y };
+			location_Y += Phobos::UI::SuperWeaponSidebar_CameoHeight / 2;
+			location.X += cameoWidth + Phobos::UI::SuperWeaponSidebar_Interval;
+			location.Y = location_Y + cameoHarfInterval;
 		}
 		else
 		{
-			location.Y += cameoHeight;
+			location.Y += Phobos::UI::SuperWeaponSidebar_CameoHeight;
 		}
 	}
 
 	for (const auto column : columns)
-		column->SetHeight(column->Buttons.size() * 48);
+		column->SetHeight(column->Buttons.size() * Phobos::UI::SuperWeaponSidebar_CameoHeight);
 
 	if (const auto toggleButton = this->ToggleButton)
 		toggleButton->UpdatePosition();

--- a/src/Ext/Sidebar/SWSidebar/SWSidebarClass.cpp
+++ b/src/Ext/Sidebar/SWSidebar/SWSidebarClass.cpp
@@ -257,15 +257,12 @@ DEFINE_HOOK(0x6A5839, SidebarClass_InitIO_InitializeSWSidebar, 0x5)
 
 	if (const auto pSideExt = SideExt::ExtMap.Find(SideClass::Array->Items[ScenarioClass::Instance->PlayerSideIndex]))
 	{
-		if (const auto toggleShape = pSideExt->SuperWeaponSidebar_ToggleShape.Get())
+		if (const auto toggleButton = DLLCreate<ToggleSWButtonClass>(SWButtonClass::StartID + SuperWeaponTypeClass::Array->Count, 0, 0, 10, 50))
 		{
-			if (const auto toggleButton = DLLCreate<ToggleSWButtonClass>(SWButtonClass::StartID + SuperWeaponTypeClass::Array->Count, 0, 0, toggleShape->Width, toggleShape->Height))
-			{
-				toggleButton->Zap();
-				GScreenClass::Instance->AddButton(toggleButton);
-				SWSidebarClass::Instance.ToggleButton = toggleButton;
-				toggleButton->UpdatePosition();
-			}
+			toggleButton->Zap();
+			GScreenClass::Instance->AddButton(toggleButton);
+			SWSidebarClass::Instance.ToggleButton = toggleButton;
+			toggleButton->UpdatePosition();
 		}
 	}
 

--- a/src/Ext/Sidebar/SWSidebar/SWSidebarClass.cpp
+++ b/src/Ext/Sidebar/SWSidebar/SWSidebarClass.cpp
@@ -1,8 +1,10 @@
 #include "SWSidebarClass.h"
 #include <CommandClass.h>
+#include <sstream>
+
 #include <Ext/House/Body.h>
 #include <Ext/Side/Body.h>
-#include <sstream>
+#include <Ext/SWType/Body.h>
 
 SWSidebarClass SWSidebarClass::Instance;
 CommandClass* SWSidebarClass::Commands[10];

--- a/src/Ext/Sidebar/SWSidebar/ToggleSWButtonClass.cpp
+++ b/src/Ext/Sidebar/SWSidebar/ToggleSWButtonClass.cpp
@@ -20,21 +20,18 @@ bool ToggleSWButtonClass::Draw(bool forced)
 		return false;
 
 	const auto pSideExt = SideExt::ExtMap.Find(SideClass::Array->Items[ScenarioClass::Instance->PlayerSideIndex]);
-	const auto pShape = pSideExt->SuperWeaponSidebar_ToggleShape.Get();
+	const auto pTogglePCX = SWSidebarClass::IsEnabled() ? pSideExt->SuperWeaponSidebar_OnPCX.GetSurface() : pSideExt->SuperWeaponSidebar_OffPCX.GetSurface();
 
-	if (!pShape)
+	if (!pTogglePCX)
 		return false;
 
-	const auto pConvert = FileSystem::SIDEBAR_PAL();
-	const auto pSurface = DSurface::Composite();
-	Point2D position = { this->X, this->Y };
-	RectangleStruct destRect = { position.X, position.Y, this->Width, this->Height };
-	pSurface->DrawSHP(pConvert, pShape, SWSidebarClass::IsEnabled(), &position, &destRect, BlitterFlags::bf_400, 0, 0, ZGradient::Ground, 1000, 0, nullptr, 0, 0, 0);
+	RectangleStruct destRect { this->X, this->Y, this->Width, this->Height };
+	PCX::Instance->BlitToSurface(&destRect, DSurface::Composite, pTogglePCX);
 
 	if (this->IsHovering)
 	{
 		const COLORREF tooltipColor = Drawing::RGB_To_Int(Drawing::TooltipColor());
-		pSurface->DrawRect(&destRect, tooltipColor);
+		DSurface::Composite->DrawRect(&destRect, tooltipColor);
 	}
 
 	return true;
@@ -69,6 +66,11 @@ bool ToggleSWButtonClass::Action(GadgetFlag flags, DWORD* pKey, KeyModifier modi
 	auto& columns = SWSidebarClass::Instance.Columns;
 
 	if (columns.empty())
+		return false;
+
+	const auto pSideExt = SideExt::ExtMap.Find(SideClass::Array->Items[ScenarioClass::Instance->PlayerSideIndex]);
+
+	if (SWSidebarClass::IsEnabled() ? !pSideExt->SuperWeaponSidebar_OnPCX.GetSurface() : !pSideExt->SuperWeaponSidebar_OffPCX.GetSurface())
 		return false;
 
 	if ((int)flags & (int)GadgetFlag::LeftPress)

--- a/src/Ext/Sidebar/SWSidebar/ToggleSWButtonClass.cpp
+++ b/src/Ext/Sidebar/SWSidebar/ToggleSWButtonClass.cpp
@@ -7,7 +7,7 @@
 #include <Ext/Side/Body.h>
 
 ToggleSWButtonClass::ToggleSWButtonClass(unsigned int id, int x, int y, int width, int height)
-	: ControlClass(id, x, y, width, height, static_cast<GadgetFlag>((int)GadgetFlag::LeftPress | (int)GadgetFlag::LeftRelease), true)
+	: ControlClass(id, x, y, width, height, (GadgetFlag::LeftPress | GadgetFlag::LeftRelease), true)
 {
 	SWSidebarClass::Instance.ToggleButton = this;
 }
@@ -73,10 +73,10 @@ bool ToggleSWButtonClass::Action(GadgetFlag flags, DWORD* pKey, KeyModifier modi
 	if (SWSidebarClass::IsEnabled() ? !pSideExt->SuperWeaponSidebar_OnPCX.GetSurface() : !pSideExt->SuperWeaponSidebar_OffPCX.GetSurface())
 		return false;
 
-	if ((int)flags & (int)GadgetFlag::LeftPress)
+	if (flags & GadgetFlag::LeftPress)
 		this->IsPressed = true;
 
-	if (((int)flags & (int)GadgetFlag::LeftRelease) && this->IsPressed)
+	if ((flags & GadgetFlag::LeftRelease) && this->IsPressed)
 	{
 		this->IsPressed = false;
 		VocClass::PlayGlobal(RulesClass::Instance->GUIMainButtonSound, 0x2000, 1.0);

--- a/src/Ext/Team/Hooks.cpp
+++ b/src/Ext/Team/Hooks.cpp
@@ -1,12 +1,33 @@
 #include "Body.h"
-
+#include <Utilities/AresHelper.h>
 
 // Bugfix: TAction 7,80,107.
-DEFINE_HOOK(0x65DF81, TeamTypeClass_CreateMembers_LoadOntoTransport, 0x7)
+DEFINE_HOOK(0x65DF67, TeamTypeClass_CreateMembers_LoadOntoTransport, 0x6)
 {
+	if(!AresHelper::CanUseAres) // If you're not using Ares you don't deserve a fix
+		return 0;
+
 	GET(FootClass* const, pPayload, EAX);
 	GET(FootClass* const, pTransport, ESI);
 	GET(TeamClass* const, pTeam, EBP);
+	GET(TeamTypeClass const*, pThis, EBX);
+
+	auto unmarkPayloadCreated = [](FootClass* member){reinterpret_cast<char*>(member->align_154)[0x9E] = false;};
+
+	if (!pTransport)
+	{
+		for (auto pNext = pPayload;
+		pNext && pNext != pTransport && pNext->Team == pTeam;
+		pNext = abstract_cast<FootClass*>(pNext->NextObject))
+			unmarkPayloadCreated(pNext);
+
+		return 0x65DFE8;
+	}
+
+	unmarkPayloadCreated(pTransport);
+
+	if (!pPayload || !pThis->Full)
+		return 0x65E004;
 
 	const bool isTransportOpenTopped = pTransport->GetTechnoType()->OpenTopped;
 	FootClass* pGunner = nullptr;
@@ -29,6 +50,5 @@ DEFINE_HOOK(0x65DF81, TeamTypeClass_CreateMembers_LoadOntoTransport, 0x7)
 	if (pTransport->GetTechnoType()->Gunner && pGunner)
 		pTransport->ReceiveGunner(pGunner);
 
-	// Ares' CreateInitialPayload doesn't work here
 	return 0x65DF8D;
 }

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -79,7 +79,9 @@ DEFINE_HOOK(0x6F9FA9, TechnoClass_AI_PromoteAnim, 0x6)
 			promAnim = GameCreate<AnimClass>(RulesExt::Global()->Promote_VeteranAnimation, pThis->GetCenterCoords());
 		else if (RulesExt::Global()->Promote_EliteAnimation)
 			promAnim = GameCreate<AnimClass>(RulesExt::Global()->Promote_EliteAnimation, pThis->GetCenterCoords());
-		promAnim->SetOwnerObject(pThis);
+
+		if(promAnim)
+			promAnim->SetOwnerObject(pThis);
 	}
 
 	return aresProcess();

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -720,7 +720,7 @@ DEFINE_HOOK(0x4D580B, FootClass_ApproachTarget_DeployToFire, 0x6)
 
 DEFINE_HOOK(0x741050, UnitClass_CanFire_DeployToFire, 0x6)
 {
-	enum { SkipGameCode = 0x741086, MustDeploy = 0x7410A8 };
+	enum { SkipGameCode = 0x7410B7, MustDeploy = 0x7410A8 };
 
 	GET(UnitClass*, pThis, ESI);
 
@@ -1059,6 +1059,86 @@ DEFINE_HOOK(0x743664, UnitClass_ReadFromINI_Follower3, 0x6)
 	}
 
 	units.clear();
+
+	return SkipGameCode;
+}
+
+#pragma endregion
+
+#pragma region StopEventFix
+
+DEFINE_HOOK(0x4C75DA, EventClass_RespondToEvent_Stop, 0x6)
+{
+	enum { SkipGameCode = 0x4C762A };
+
+	GET(TechnoClass* const, pTechno, ESI);
+
+	// Check aircraft
+	const auto pAircraft = abstract_cast<AircraftClass*>(pTechno);
+	const bool commonAircraft = pAircraft && !pAircraft->Airstrike && !pAircraft->Spawned;
+	const auto mission = pTechno->CurrentMission;
+
+	// To avoid aircraft overlap by keep link if is returning or is in airport now.
+	if (!commonAircraft || (mission != Mission::Sleep && mission != Mission::Guard && mission != Mission::Enter)
+		|| !pAircraft->DockNowHeadingTo || (pAircraft->DockNowHeadingTo != pAircraft->GetNthLink()))
+	{
+		pTechno->SendToEachLink(RadioCommand::NotifyUnlink);
+	}
+
+	// To avoid technos being unable to stop in attack move mega mission
+	if (pTechno->MegaMissionIsAttackMove())
+		pTechno->ClearMegaMissionData();
+
+	// Clearing the current target should still be necessary for all technos
+	pTechno->SetTarget(nullptr);
+
+	if (commonAircraft)
+	{
+		if (pAircraft->Type->AirportBound)
+		{
+			// To avoid `AirportBound=yes` aircraft with ammo at low altitudes cannot correctly receive stop command and queue Mission::Guard with a `Destination`.
+			if (pAircraft->Ammo)
+				pTechno->SetDestination(nullptr, true);
+
+			// To avoid `AirportBound=yes` aircraft pausing in the air and let they returning to air base immediately.
+			if (!pAircraft->DockNowHeadingTo || (pAircraft->DockNowHeadingTo != pAircraft->GetNthLink())) // If the aircraft have no valid dock, try to find a new one
+				pAircraft->EnterIdleMode(false, true);
+		}
+		else if (pAircraft->Ammo)
+		{
+			// To avoid `AirportBound=no` aircraft ignoring the stop task or directly return to the airport.
+			if (pAircraft->Destination && static_cast<int>(CellClass::Coord2Cell(pAircraft->Destination->GetCoords()).DistanceFromSquared(pAircraft->GetMapCoords())) > 2) // If the aircraft is moving, find the forward cell then stop in it
+				pAircraft->SetDestination(pAircraft->GetCell()->GetNeighbourCell(static_cast<FacingType>(pAircraft->PrimaryFacing.Current().GetValue<3>())), true);
+		}
+		else if (!pAircraft->DockNowHeadingTo || (pAircraft->DockNowHeadingTo != pAircraft->GetNthLink()))
+		{
+			pAircraft->EnterIdleMode(false, true);
+		}
+		// Otherwise landing or idling normally without answering the stop command
+	}
+	else
+	{
+		// Check Jumpjets
+		const auto pFoot = abstract_cast<FootClass*>(pTechno);
+		const auto pJumpjetLoco = pFoot ? locomotion_cast<JumpjetLocomotionClass*>(pFoot->Locomotor) : nullptr;
+
+		// Clear archive target for infantries and vehicles like receive a mega mission
+		if (pFoot && !pAircraft)
+			pTechno->SetArchiveTarget(nullptr);
+
+		// To avoid foots stuck in Mission::Area_Guard
+		if (pTechno->CurrentMission == Mission::Area_Guard && !pTechno->GetTechnoType()->DefaultToGuardArea)
+			pTechno->QueueMission(Mission::Guard, true);
+
+		// To avoid jumpjets falling into a state of standing idly by
+		if (!pJumpjetLoco) // If is not jumpjet, clear the destination is enough
+			pTechno->SetDestination(nullptr, true);
+		else if (!pFoot->Destination) // When in attack move and have had a target, the destination will be cleaned up, enter the guard mission can prevent the jumpjets stuck in a status of standing idly by
+			pTechno->QueueMission(Mission::Guard, true);
+		else if (static_cast<int>(CellClass::Coord2Cell(pFoot->Destination->GetCoords()).DistanceFromSquared(pTechno->GetMapCoords())) > 2) // If the jumpjet is moving, find the forward cell then stop in it
+			pTechno->SetDestination(pTechno->GetCell()->GetNeighbourCell(static_cast<FacingType>(pJumpjetLoco->LocomotionFacing.Current().GetValue<3>())), true);
+		// Otherwise landing or idling normally without answering the stop command
+	}
 
 	return SkipGameCode;
 }

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -32,7 +32,6 @@
 #include <Utilities/Macro.h>
 #include <Utilities/Debug.h>
 #include <Utilities/TemplateDef.h>
-#include <Utilities/AresFunctions.h>
 
 /*
 	Allow usage of TileSet of 255 and above without making NE-SW broken bridges unrepairable
@@ -1170,55 +1169,3 @@ size_t __fastcall HexStr2Int_replacement(const char* str)
 }
 DEFINE_JUMP(CALL, 0x6E8305, GET_OFFSET(HexStr2Int_replacement)); // TaskForce
 DEFINE_JUMP(CALL, 0x6E5FA6, GET_OFFSET(HexStr2Int_replacement)); // TagType
-
-// This is the inline function to get the academy type that a techno enjoys.
-inline static const AbstractType GetAresAcademyType(TechnoClass* pTechno)
-{
-	if (pTechno->WhatAmI() == AbstractType::Unit)
-	{
-		if (pTechno->GetTechnoType()->ConsideredAircraft)
-			return AbstractType::Aircraft;
-		else if (pTechno->GetTechnoType()->Organic)
-			return AbstractType::Infantry;
-		else
-			return AbstractType::Unit;
-	}
-	else if (pTechno->WhatAmI() == AbstractType::Infantry
-		|| pTechno->WhatAmI() == AbstractType::Aircraft
-		|| pTechno->WhatAmI() == AbstractType::Building)
-	{
-		return pTechno->WhatAmI();
-	}
-	return AbstractType::None;
-}
-
-// This is a fix to the Ares bug: Academy feature doesn't apply to the initial payload of vehicles built off a War Factory.
-// Curiously, Academy applies to the initial payloads of vehicles under any other circumstances, even when built off a Naval Shipyard.
-// It is "Unsorted::IKnowWhatImDoing" prevented the "HouseExt::ApplyAcademy" from taking effect.
-// The fix is simple, when Ares is supposed to have initialized the initial payload, and Academy is prevented from taking any effect,
-// temporarily turn off "Unsorted::IKnowWhatImDoing", invoke "HouseExt::ApplyAcademy", then turn on "Unsorted::IKnowWhatImDoing" again.
-DEFINE_HOOK(0x4D71A0, FootClass_Put_InitialPayload_AfterAres, 0x6)
-{
-	GET(FootClass* const, pThis, ESI);
-
-	if (AresFunctions::ApplyAcademy && Unsorted::IKnowWhatImDoing)
-	{
-		if (pThis && !pThis->InLimbo && pThis->IsOnMap && pThis->WhatAmI() == AbstractType::Unit
-			&& pThis->GetTechnoType()->Passengers > 0
-			&& pThis->Passengers.NumPassengers > 0)
-		{
-			for (auto pNext = pThis->Passengers.FirstPassenger; pNext; pNext = abstract_cast<FootClass*>(pNext->NextObject))
-			{
-				auto abstractType = GetAresAcademyType(pNext);
-				if (abstractType != AbstractType::None)
-				{
-					--Unsorted::IKnowWhatImDoing;
-					AresFunctions::ApplyAcademy(AresFunctions::HouseExtMap_Find(pNext->Owner), pNext, abstractType);
-					++Unsorted::IKnowWhatImDoing;
-				}
-			}
-		}
-	}
-
-	return 0;
-}

--- a/src/Phobos.INI.cpp
+++ b/src/Phobos.INI.cpp
@@ -35,9 +35,10 @@ double Phobos::UI::PowerDelta_ConditionRed = 1.0;
 bool Phobos::UI::CenterPauseMenuBackground = false;
 bool Phobos::UI::SuperWeaponSidebar = false;
 int Phobos::UI::SuperWeaponSidebar_Interval = 0;
+int Phobos::UI::SuperWeaponSidebar_LeftOffset = 0;
+int Phobos::UI::SuperWeaponSidebar_CameoHeight = 48;
 int Phobos::UI::SuperWeaponSidebar_Max = 0;
 int Phobos::UI::SuperWeaponSidebar_MaxColumns = INT32_MAX;
-int Phobos::UI::SuperWeaponSidebar_CameoHeight = 48;
 bool Phobos::UI::WeedsCounter_Show = false;
 bool Phobos::UI::AnchoredToolTips = false;
 
@@ -173,6 +174,16 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 		Phobos::UI::SuperWeaponSidebar_Interval =
 			ini_uimd.ReadInteger(SIDEBAR_SECTION, "SuperWeaponSidebar.Interval", Phobos::UI::SuperWeaponSidebar_Interval);
 
+		Phobos::UI::SuperWeaponSidebar_LeftOffset =
+			ini_uimd.ReadInteger(SIDEBAR_SECTION, "SuperWeaponSidebar.LeftOffset", Phobos::UI::SuperWeaponSidebar_LeftOffset);
+
+		Phobos::UI::SuperWeaponSidebar_LeftOffset = std::min(Phobos::UI::SuperWeaponSidebar_Interval, Phobos::UI::SuperWeaponSidebar_LeftOffset);
+
+		Phobos::UI::SuperWeaponSidebar_CameoHeight =
+			ini_uimd.ReadInteger(SIDEBAR_SECTION, "SuperWeaponSidebar.CameoHeight", Phobos::UI::SuperWeaponSidebar_CameoHeight);
+
+		Phobos::UI::SuperWeaponSidebar_CameoHeight = std::max(48, Phobos::UI::SuperWeaponSidebar_CameoHeight);
+
 		Phobos::UI::SuperWeaponSidebar_Max =
 			ini_uimd.ReadInteger(SIDEBAR_SECTION, "SuperWeaponSidebar.Max", Phobos::UI::SuperWeaponSidebar_Max);
 
@@ -181,7 +192,7 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 		if (Phobos::UI::SuperWeaponSidebar_Max > 0)
 			Phobos::UI::SuperWeaponSidebar_Max = std::min(Phobos::UI::SuperWeaponSidebar_Max, screenHeight / Phobos::UI::SuperWeaponSidebar_CameoHeight);
 		else
-			Phobos::UI::SuperWeaponSidebar_Max = screenHeight / Phobos::UI::SuperWeaponSidebar_CameoHeight;
+			Phobos::UI::SuperWeaponSidebar_Max = (screenHeight - 40) / Phobos::UI::SuperWeaponSidebar_CameoHeight;
 
 		Phobos::UI::SuperWeaponSidebar_MaxColumns =
 			ini_uimd.ReadInteger(SIDEBAR_SECTION, "SuperWeaponSidebar.MaxColumns", Phobos::UI::SuperWeaponSidebar_MaxColumns);

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -55,9 +55,10 @@ public:
 		static bool CenterPauseMenuBackground;
 		static bool SuperWeaponSidebar;
 		static int SuperWeaponSidebar_Interval;
+		static int SuperWeaponSidebar_LeftOffset;
+		static int SuperWeaponSidebar_CameoHeight;
 		static int SuperWeaponSidebar_Max;
 		static int SuperWeaponSidebar_MaxColumns;
-		static int SuperWeaponSidebar_CameoHeight;
 		static bool WeedsCounter_Show;
 		static bool AnchoredToolTips;
 

--- a/src/Utilities/AresAddressInit.cpp
+++ b/src/Utilities/AresAddressInit.cpp
@@ -6,14 +6,10 @@
 decltype(AresFunctions::ConvertTypeTo) AresFunctions::ConvertTypeTo = nullptr;
 decltype(AresFunctions::SpawnSurvivors) AresFunctions::SpawnSurvivors = nullptr;
 decltype(AresFunctions::IsTargetConstraintsEligible) AresFunctions::IsTargetConstraintsEligible = nullptr;
-decltype(AresFunctions::ApplyAcademy) AresFunctions::ApplyAcademy = nullptr;
 std::function<AresSWTypeExtData* (SuperWeaponTypeClass*)> AresFunctions::SWTypeExtMap_Find;
-std::function<AresHouseExtData* (HouseClass*)> AresFunctions::HouseExtMap_Find;
 
 void* AresFunctions::_SWTypeExtMap = nullptr;
 decltype(AresFunctions::_SWTypeExtMapFind) AresFunctions::_SWTypeExtMapFind = nullptr;
-void* AresFunctions::_HouseExtMap = nullptr;
-decltype(AresFunctions::_HouseExtMapFind) AresFunctions::_HouseExtMapFind = nullptr;
 
 void Apply_Ares3_0_Patches();
 void Apply_Ares3_0p1_Patches();
@@ -33,15 +29,9 @@ void AresFunctions::InitAres3_0()
 
 	NOTE_ARES_FUN(IsTargetConstraintsEligible, 0x032110);
 
-	NOTE_ARES_FUN(ApplyAcademy, 0x020750);
-
 	NOTE_ARES_FUN(_SWTypeExtMapFind, 0x57C70);
 	NOTE_ARES_FUN(_SWTypeExtMap, 0xC1C54);
 	SWTypeExtMap_Find = [](SuperWeaponTypeClass* swt) { return _SWTypeExtMapFind(_SWTypeExtMap, swt); };
-
-	NOTE_ARES_FUN(_HouseExtMapFind, 0x57C70);
-	NOTE_ARES_FUN(_HouseExtMap, 0xC1AA8);
-	HouseExtMap_Find = [](HouseClass* houseClass) { return _HouseExtMapFind(_HouseExtMap, houseClass); };
 
 #ifndef USING_MULTIFINITE_SYRINGE
 	Apply_Ares3_0_Patches();
@@ -63,15 +53,9 @@ void AresFunctions::InitAres3_0p1()
 
 	NOTE_ARES_FUN(IsTargetConstraintsEligible, 0x032AF0);
 
-	NOTE_ARES_FUN(ApplyAcademy, 0x0211D0);
-
 	NOTE_ARES_FUN(_SWTypeExtMapFind, 0x58900);
 	NOTE_ARES_FUN(_SWTypeExtMap, 0xC2C50);
 	SWTypeExtMap_Find = [](SuperWeaponTypeClass* swt) { return _SWTypeExtMapFind(_SWTypeExtMap, swt); };
-
-	NOTE_ARES_FUN(_HouseExtMapFind, 0x589A0);
-	NOTE_ARES_FUN(_HouseExtMap, 0xC2B08);
-	HouseExtMap_Find = [](HouseClass* houseClass) { return _HouseExtMapFind(_HouseExtMap, houseClass); };
 
 #ifndef USING_MULTIFINITE_SYRINGE
 	Apply_Ares3_0p1_Patches();

--- a/src/Utilities/AresFunctions.h
+++ b/src/Utilities/AresFunctions.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <functional>
-#include <GeneralDefinitions.h>
 class TechnoClass;
 class TechnoTypeClass;
 class FootClass;
@@ -28,11 +27,7 @@ public:
 
 	static bool(__thiscall* IsTargetConstraintsEligible)(void*, HouseClass*, bool);
 
-	static void(__thiscall* ApplyAcademy)(void*, TechnoClass* pTechno, AbstractType considerAs);
-
 	static std::function<AresSWTypeExtData* (SuperWeaponTypeClass*)> SWTypeExtMap_Find;
-
-	static std::function<AresHouseExtData* (HouseClass*)> HouseExtMap_Find;
 
 private:
 
@@ -41,7 +36,5 @@ private:
 	static constexpr bool AresWasWrongAboutSpawnSurvivors = _maybe;
 
 	static void* _SWTypeExtMap;
-	static void* _HouseExtMap;
 	static AresSWTypeExtData* (__thiscall* _SWTypeExtMapFind)(void*, SuperWeaponTypeClass*);
-	static AresHouseExtData* (__thiscall* _HouseExtMapFind)(void*, HouseClass*);
 };


### PR DESCRIPTION
暂时未解决和 `LimboDelivery` 与 `UseAITargeting` 的冲突。

包含的内容：
- 移除与侧边栏无关的部分
- 将背景的SHP改为PCX
- 图标根据所属方优先级先进行排序
- 图标在上下之间的距离（包括图标本身的高度）和图标在左右之间的偏移
- 修复栏目回收机制的问题
- 鼠标在背景上时重置指针图形并跳过点击行为

可能还需要：
- 更简单一点的判断栏目高度（直接通过一个 画背景=yes 的判断可能更方便，这种情况下还没有pcx可画就画个黑色长方形，如何？现在采用的依然是看玩家所属阵营的背景是否存在）